### PR TITLE
Fix typo causing timeout not to be read from config

### DIFF
--- a/SGSConfig.cpp
+++ b/SGSConfig.cpp
@@ -131,7 +131,7 @@ CSGSConfig::CSGSConfig(const std::string &pathname)
 		CUtils::ToUpper(pmod->permanent);
 
 		int ivalue;
-		sprintf(key, "module.[%d].usertimout", i);
+		sprintf(key, "module.[%d].usertimeout", i);
 		get_value(cfg, key, ivalue, 0, 300, 300);
 		pmod->usertimeout = (unsigned int)ivalue;
 


### PR DESCRIPTION
Hi this fixes a bug where the user timeout was not loaded from the configuration

73
Geoffrey F4FXL / KC3FRA