### PR TITLE
Use example.cfg as default config, do not overwrite existing config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ newhostfiles :
 
 install : sgs
 	/bin/cp -f sgs $(BINDIR)
-	/bin/cp -f sgs.cfg $(CFGDIR)
+	/bin/cp -i example.cfg $(CFGDIR)/sgs.cfg 
 	/bin/cp -f sgs.service /lib/systemd/system
 	systemctl enable sgs.service
 	systemctl daemon-reload


### PR DESCRIPTION
If sgs.cfg was not created make install would fail. This fixes this by
using example.cfg as default config file.
This also prompts the user in case the file already exists.